### PR TITLE
Fixed an error inside the promised_cupcake.mcfunction recipe cleaning

### DIFF
--- a/cnk/data/cnk/function/recipes/cooking_pot/promised_cupcake.mcfunction
+++ b/cnk/data/cnk/function/recipes/cooking_pot/promised_cupcake.mcfunction
@@ -1,8 +1,7 @@
 function cnk:recipes/remove_generic/egg
-
 function cnk:recipes/remove_generic/water
 
-data modify storage cnk:temp cooking_pot.slot set from storage cnk:temp cooking_pot.Items[{components:{"minecraft:custom_data":{cnk:{ingredient:{type:"chili_pepper"}}}}}].Slot
+data modify storage cnk:temp cooking_pot.slot set from storage cnk:temp cooking_pot.Items[{id:"minecraft:sugar"}].Slot
 function cnk:recipes/remove with storage cnk:temp cooking_pot
 
 data modify storage cnk:temp cooking_pot.slot set from storage cnk:temp cooking_pot.Items[{id:"minecraft:wheat"}].Slot


### PR DESCRIPTION
Fixed an error inside the promised_cupcake.mcfunction recipe cleaning code where instead of sugar, chili pepper was referenced leading to the sugar staying inside the cooking pot.

I think it's because the code was pasted from the infernal_cupcake recipe.