### PR TITLE
fix: derive Spirit Sprite aging from days_in_a_year

### DIFF
--- a/cnk/data/cnk/function/wine_rack/interact/sprite/on_wine_rack.mcfunction
+++ b/cnk/data/cnk/function/wine_rack/interact/sprite/on_wine_rack.mcfunction
@@ -1,7 +1,8 @@
 execute store result score $wine_count cnk.dummy run data get entity @s item.components."minecraft:bundle_contents"
 execute if score $wine_count cnk.dummy matches 0 run return fail
 
-scoreboard players set $age_amount cnk.dummy 384000
+scoreboard players set $age_amount cnk.dummy 24000
+scoreboard players operation $age_amount cnk.dummy *= $days_in_a_year cnk.dummy
 scoreboard players operation $age_amount cnk.dummy /= $wine_count cnk.dummy
 execute if score $age_amount cnk.dummy matches 0 run return fail
 


### PR DESCRIPTION
Hi! First off, thank you for Crop & Kettle — the wine aging system is genuinely one of the most charming mechanics we've added to our server, and the admin panel made it easy to tune. While adjusting `days_in_a_year` I ran into a small thing I thought was worth reporting.

**Version:** v1.3.12 · Minecraft 26.1.2 (Paper) · `days_in_a_year` set to 72

## What happens

The Spirit Sprite subtracts a fixed `384000` ticks from `wine.time`, split across the bottles on the rack:

| `days_in_a_year` | 384000 ticks equals |
|---:|---|
| 16 (default) | 1.00 year |
| 36 | 0.44 year |
| 72 | **0.22 year** |
| 144 | 0.11 year |

On our server at 72, using a sprite on a single bottle moves the displayed age so little that players assume the item is broken.

### Possible fix

Deriving the value from the setting keeps the default behaviour identical while following the configuration:

```mcfunction
scoreboard players set $age_amount cnk.dummy 24000
scoreboard players operation $age_amount cnk.dummy *= $days_in_a_year cnk.dummy
scoreboard players operation $age_amount cnk.dummy /= $wine_count cnk.dummy
```
