### PR TITLE
Creeping Wine explosion count scales with days_in_a_year because of a hardcoded 3840000 ticks

### DIFF
--- a/cnk/data/cnk/function/drinks/creeping_wine/effect/explode.mcfunction
+++ b/cnk/data/cnk/function/drinks/creeping_wine/effect/explode.mcfunction
@@ -3,7 +3,9 @@ execute if score @s cnk.wine_time_cooldown matches 0.. run return run scoreboard
 function cnk:drinks/year_delta/main
 
 #add 10 years
-scoreboard players add @s cnk.wine_time 3840000
+scoreboard players set $age_step cnk.dummy 240000
+scoreboard players operation $age_step cnk.dummy *= $days_in_a_year cnk.dummy
+scoreboard players operation @s cnk.wine_time += $age_step cnk.dummy
 
 # minimum explosion power of 2
 scoreboard players add $year cnk.dummy 2


### PR DESCRIPTION
Hi again! This is a sibling to the Spirit Sprite report — same root cause, opposite effect, so I figured it deserved its own issue rather than being buried in the other one.

**Version:** v1.3.12 · Minecraft 26.1.2 (Paper) · `days_in_a_year` set to 72

### What happens

`cnk/data/cnk/function/drinks/creeping_wine/effect/explode.mcfunction` advances the marker's `wine_time` by a fixed amount each pass, looping until it catches up with the current gametime:

```mcfunction
#add 10 years
scoreboard players add @s cnk.wine_time 3840000
```

The comment says it best — the intent is ten years. That constant is `160 × 24000`, which is exactly ten years at the default setting. The number of explosion volleys therefore works out to `age_in_ticks / 3840000`.

Because the ticks behind a *displayed* year depend on `days_in_a_year`, raising the setting increases how many volleys a wine of the same apparent age produces:

| Wine's displayed age | at 16 (default) | at 72 |
|---:|---:|---:|
| 10 years | 1 | 5 |
| 25 years | 3 | 12 |
| 50 years | 5 | 23 |
| 100 years | 10 | **45** |

A century-old bottle going from 10 volleys to 45 is quite a jump for survival builds — we caught it on a test world before it reached anyone's base, thankfully. Worth noting this runs opposite to the Spirit Sprite issue, which gets *weaker* with the same setting, so a server owner raising `days_in_a_year` gets hit from both directions at once.

### Possible fix

`scoreboard players add` only takes a literal, so this one needs to go through `operation +=`:

```mcfunction
#add 10 years
scoreboard players set $age_step cnk.dummy 240000
scoreboard players operation $age_step cnk.dummy *= $days_in_a_year cnk.dummy
scoreboard players operation @s cnk.wine_time += $age_step cnk.dummy
```

`240000` is `10 × 24000`. `$age_step` is a new fake player name — I checked it doesn't collide with anything in the pack, and it sits alongside the existing `$age_amount` / `$age_increase` naming. At the maximum allowed setting (365) this reaches 87,600,000, still within signed 32-bit range.
